### PR TITLE
show price with decimal part (improvement)

### DIFF
--- a/snippets/tag-label.liquid
+++ b/snippets/tag-label.liquid
@@ -1,8 +1,8 @@
 {% assign tag_label = tag.label %}
 {% if tag.group_type == "range" or tag.group_type == "pricerange" %}
     {% if tag.lower or tag.upper %}
-        {% capture tag_lower %}{% if tag.lower %}{% if tag.group_type == "pricerange" %}{{ tag.lower | times: 100 | money_without_decimal_part }}{% else %}{{ tag.lower }}{% endif %}{% endif %}{% endcapture %}
-        {% capture tag_upper %}{% if tag.upper %}{% if tag.group_type == "pricerange" %}{{ tag.upper | times: 100 | money_without_decimal_part }}{% else %}{{ tag.upper }}{% endif %}{% endif %}{% endcapture %}
+        {% capture tag_lower %}{% if tag.lower %}{% if tag.group_type == "pricerange" %}{{ tag.lower | money_without_decimal_part }}{% else %}{{ tag.lower }}{% endif %}{% endif %}{% endcapture %}
+        {% capture tag_upper %}{% if tag.upper %}{% if tag.group_type == "pricerange" %}{{ tag.upper | money_without_decimal_part }}{% else %}{{ tag.upper }}{% endif %}{% endif %}{% endcapture %}
         {% capture tag_label_template %}tags.{{ tag.group_type }}.{% if tag.lower and tag.upper %}between{% elsif tag.lower %}greater{% elsif tag.upper %}less{% endif %}{% endcapture %}
         {% capture tag_label %}{{ tag_label_template | t:  tag_lower, tag_upper }}{% endcapture %}
     {% endif %}

--- a/snippets/tag-label.liquid
+++ b/snippets/tag-label.liquid
@@ -1,8 +1,8 @@
 {% assign tag_label = tag.label %}
 {% if tag.group_type == "range" or tag.group_type == "pricerange" %}
     {% if tag.lower or tag.upper %}
-        {% capture tag_lower %}{% if tag.lower %}{% if tag.group_type == "pricerange" %}{{ tag.lower | money_without_decimal_part }}{% else %}{{ tag.lower }}{% endif %}{% endif %}{% endcapture %}
-        {% capture tag_upper %}{% if tag.upper %}{% if tag.group_type == "pricerange" %}{{ tag.upper | money_without_decimal_part }}{% else %}{{ tag.upper }}{% endif %}{% endif %}{% endcapture %}
+        {% capture tag_lower %}{% if tag.lower %}{% if tag.group_type == "pricerange" %}{{ tag.lower | money_with_currency }}{% else %}{{ tag.lower }}{% endif %}{% endif %}{% endcapture %}
+        {% capture tag_upper %}{% if tag.upper %}{% if tag.group_type == "pricerange" %}{{ tag.upper | money_with_currency }}{% else %}{{ tag.upper }}{% endif %}{% endif %}{% endcapture %}
         {% capture tag_label_template %}tags.{{ tag.group_type }}.{% if tag.lower and tag.upper %}between{% elsif tag.lower %}greater{% elsif tag.upper %}less{% endif %}{% endcapture %}
         {% capture tag_label %}{{ tag_label_template | t:  tag_lower, tag_upper }}{% endcapture %}
     {% endif %}


### PR DESCRIPTION
After talking with BA we had a suggestion to show price in filter with same format as in products grid
for https://github.com/VirtoCommerce/vc-theme-default/issues/111
![default_filter](https://user-images.githubusercontent.com/22875828/69521145-fdf51680-0f66-11ea-9468-0f2c13e020b9.png)
