### PR TITLE
#134: Remove redundant action in error handling

### DIFF
--- a/assets/js/cart.js
+++ b/assets/js/cart.js
@@ -39,7 +39,6 @@ storefrontApp.controller('cartController', ['$rootScope', '$scope', '$timeout', 
     		getCart();
     		$rootScope.$broadcast('cartItemsChanged');
     	}, function (response) {
-    		$scope.cart.items = initialItems;
     		$scope.cartIsUpdating = false;
     	});
     };


### PR DESCRIPTION
In `changeLineItemPrice` method, in case of the error, cart items were assinged to non-existent `initialItems`. In fact, resotring is not neede at all here, as there were not changes with the cart items before the API service call. Changes are handled by the success callback.