### PR TITLE
VP-1172: Fix behavior of quote request form

### DIFF
--- a/assets/js/quote-request.js
+++ b/assets/js/quote-request.js
@@ -129,6 +129,9 @@ storefrontApp.controller('quoteRequestController', ['$rootScope', '$scope', '$wi
         $scope.quoteRequest.billingAddress.email = $scope.quoteRequest.email;
         if ($scope.quoteRequest.shippingAddress) {
             $scope.quoteRequest.shippingAddress.email = $scope.quoteRequest.email;
+            if ($scope.quoteRequest.shippingAddressEqualsBilling) {
+                $scope.setShippingAddressEqualsBilling();
+            }
         }
         quoteRequestService.submitQuoteRequest($scope.quoteRequest.id, toFormModel($scope.quoteRequest)).then(function (response) {
             if ($scope.customer.isRegisteredUser) {
@@ -173,6 +176,8 @@ storefrontApp.controller('quoteRequestController', ['$rootScope', '$scope', '$wi
                 $scope.shippingCountry = $scope.billingCountry;
                 getCountryRegions('Shipping', $scope.quoteRequest.shippingAddress.countryCode);
             }
+        } else {
+            $scope.quoteRequest.shippingAddress = null;
         }
     }
 

--- a/templates/quote-request.liquid
+++ b/templates/quote-request.liquid
@@ -229,7 +229,7 @@
                     <input id="ShippingAddressEqualsBilling" name="ShippingAddressEqualsBilling" type="checkbox" style="display: inline-block;" ng-model="quoteRequest.shippingAddressEqualsBilling" ng-change="setShippingAddressEqualsBilling()" />
                     <label for="ShippingAddressEqualsBilling" style="display: inline-block;">{{ 'customer.addresses.same_address' | t }}</label>
                     <input id="ShippingAddressType" name="ShippingAddressType" type="hidden" value="Shipping" ng-model="quoteRequest.shippingAddress.type" ng-init="quoteRequest.shippingAddress.type = 'Shipping'" />
-                    <div class="grid">
+                    <div class="grid" ng-if="!quoteRequest.shippingAddressEqualsBilling">
                         <div class="grid-item large--one-half">
                             <label for="ShippingAddressFirstName" style="float: left;">{{ 'customer.addresses.first_name' | t }}</label>
                             <span style="color: #ff0000; float: left; margin-left: 5px;">*</span>


### PR DESCRIPTION
Fixed scenario of setting billing and shipping addresses, now shipping address is hidden when "Shipping address is same as billing address" is checked. Also fixed scenario when billing address is populated after checking "Shipping address is same as billing address".

![quotegif](https://user-images.githubusercontent.com/22875828/86385789-2083a680-bc91-11ea-836e-eb80820d52da.gif)
