### PR TITLE
VP-3733: Show more the one users wish list 

### DIFF
--- a/assets/js/lists/account-lists.js
+++ b/assets/js/lists/account-lists.js
@@ -88,14 +88,14 @@ angular.module('storefront.account')
                                 pageSize: $ctrl.pageSettings.itemsPerPageCount,
                                 type: $ctrl.type
                             }).then(function (response) {
-                                $ctrl.accountLists.lists = response.data.results;
+                                $ctrl.accountLists.lists = response.data;
                                 $ctrl.pageSettings.totalItems = response.data.totalCount;
                                 if ($ctrl.selectedListName) {
-                                    $ctrl.accountLists.selectedList = _.find(response.data.results, function (element) { 
+                                    $ctrl.accountLists.selectedList = _.find(response.data, function (element) { 
                                         return element.name == $ctrl.selectedListName;
                                     });
                                 } else {
-                                    $ctrl.accountLists.selectedList = _.first(response.data.results);
+                                    $ctrl.accountLists.selectedList = _.first(response.data);
                                 }
                             });
                         });
@@ -144,7 +144,7 @@ angular.module('storefront.account')
                                 type: $ctrl.type
                             }).then(function (response) {
                                 var dialogData = {
-                                    lists: response.data.results,
+                                    lists: response.data,
                                     predefinedLists: $ctrl.predefinedLists,
                                     type: $ctrl.type
                                 }

--- a/assets/js/lists/add-to-list.js
+++ b/assets/js/lists/add-to-list.js
@@ -34,7 +34,7 @@ storefrontApp.controller('recentlyAddedListItemDialogController', ['$scope', '$w
             pageSize: 20,
             type: $scope.type
         }).then(function (response) {
-            $scope.lists = response.data.results;
+            $scope.lists = response.data;
             if (response.data.totalCount === 0) {
                 $scope.lists = defaultLists.default_lists;
             }


### PR DESCRIPTION
### Problem
VP-3733:  user wish list not shown when user create it in profile

### Solution
Part of solution: Fix returning object access
### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
