### PR TITLE
Added packJavaScript task to default gulp task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -202,4 +202,4 @@ exports["min:js"] = min_js;
 exports["min:css"] = min_css;
 exports["min:html"] = min_html;
 exports.compress = series(exports.min, packJavaScript, compress);
-exports.default = series(clean, lint, exports.min);
+exports.default = series(clean, lint, exports.min, exports.packJavaScript);


### PR DESCRIPTION
When running the default gulp task the `scripts_dependencies.js` file is never created, this is required to run the templates otherwise you receive an error.  The default task also cleans the directory removing the file if it was there and doesn't regenerate it.

This PR just adds the `packJavaScript` task which generates the above file so a user can run the `default` task in order to test their template changes. 